### PR TITLE
Mapping invoices to DTOs including invoice lines;

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <liquibase.version>3.5.3</liquibase.version>
         <liquibase-hibernate5.version>3.6</liquibase-hibernate5.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
-        <mapstruct.version>1.1.0.Final</mapstruct.version>
+        <mapstruct.version>1.2.0.Final</mapstruct.version>
 
         <!-- Plugin versions -->
         <maven-clean-plugin.version>2.6.1</maven-clean-plugin.version>

--- a/src/main/java/org/agoncal/sample/jhipster/bidirectmapstruct/service/InvoiceService.java
+++ b/src/main/java/org/agoncal/sample/jhipster/bidirectmapstruct/service/InvoiceService.java
@@ -1,17 +1,18 @@
 package org.agoncal.sample.jhipster.bidirectmapstruct.service;
 
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.agoncal.sample.jhipster.bidirectmapstruct.domain.Invoice;
 import org.agoncal.sample.jhipster.bidirectmapstruct.repository.InvoiceRepository;
 import org.agoncal.sample.jhipster.bidirectmapstruct.service.dto.InvoiceDTO;
 import org.agoncal.sample.jhipster.bidirectmapstruct.service.mapper.InvoiceMapper;
+import org.agoncal.sample.jhipster.bidirectmapstruct.service.mapper.MappedInvoiceTrackingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.LinkedList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Service Implementation for managing Invoice.
@@ -39,7 +40,7 @@ public class InvoiceService {
      */
     public InvoiceDTO save(InvoiceDTO invoiceDTO) {
         log.debug("Request to save Invoice : {}", invoiceDTO);
-        Invoice invoice = invoiceMapper.toEntity(invoiceDTO);
+        Invoice invoice = invoiceMapper.toEntity(invoiceDTO, new MappedInvoiceTrackingContext());
         invoice = invoiceRepository.save(invoice);
         return invoiceMapper.toDto(invoice);
     }

--- a/src/main/java/org/agoncal/sample/jhipster/bidirectmapstruct/service/dto/InvoiceDTO.java
+++ b/src/main/java/org/agoncal/sample/jhipster/bidirectmapstruct/service/dto/InvoiceDTO.java
@@ -1,11 +1,13 @@
 package org.agoncal.sample.jhipster.bidirectmapstruct.service.dto;
 
 
-import javax.validation.constraints.*;
 import java.io.Serializable;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.Objects;
+import java.util.Set;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 /**
  * A DTO for the Invoice entity.
@@ -25,6 +27,8 @@ public class InvoiceDTO implements Serializable {
     @NotNull
     @Size(max = 32)
     private String terms;
+
+    private Set<InvoiceLineDTO> lines = new HashSet<>();
 
     private Set<ContactDTO> responsibles = new HashSet<>();
 
@@ -66,6 +70,14 @@ public class InvoiceDTO implements Serializable {
 
     public void setTerms(String terms) {
         this.terms = terms;
+    }
+
+    public Set<InvoiceLineDTO> getLines() {
+        return lines;
+    }
+
+    public void setLines(Set<InvoiceLineDTO> lines) {
+        this.lines = lines;
     }
 
     public Set<ContactDTO> getResponsibles() {

--- a/src/main/java/org/agoncal/sample/jhipster/bidirectmapstruct/service/mapper/InvoiceLineMapper.java
+++ b/src/main/java/org/agoncal/sample/jhipster/bidirectmapstruct/service/mapper/InvoiceLineMapper.java
@@ -1,29 +1,30 @@
 package org.agoncal.sample.jhipster.bidirectmapstruct.service.mapper;
 
-import org.agoncal.sample.jhipster.bidirectmapstruct.domain.*;
+import org.agoncal.sample.jhipster.bidirectmapstruct.domain.Invoice;
+import org.agoncal.sample.jhipster.bidirectmapstruct.domain.InvoiceLine;
 import org.agoncal.sample.jhipster.bidirectmapstruct.service.dto.InvoiceLineDTO;
-
-import org.mapstruct.*;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 /**
  * Mapper for the entity InvoiceLine and its DTO InvoiceLineDTO.
  */
-@Mapper(componentModel = "spring", uses = {InvoiceMapper.class})
-public interface InvoiceLineMapper extends EntityMapper<InvoiceLineDTO, InvoiceLine> {
+@Mapper(componentModel = "spring")
+public interface InvoiceLineMapper {
 
     @Mapping(source = "invoice.id", target = "invoiceId")
     @Mapping(source = "invoice.number", target = "invoiceNumber")
-    InvoiceLineDTO toDto(InvoiceLine invoiceLine); 
+    InvoiceLineDTO toDto(InvoiceLine invoiceLine);
 
     @Mapping(source = "invoiceId", target = "invoice")
     InvoiceLine toEntity(InvoiceLineDTO invoiceLineDTO);
 
-    default InvoiceLine fromId(Long id) {
+    default Invoice fromId(Long id) {
         if (id == null) {
             return null;
         }
-        InvoiceLine invoiceLine = new InvoiceLine();
-        invoiceLine.setId(id);
-        return invoiceLine;
+        Invoice invoice = new Invoice();
+        invoice.setId(id);
+        return invoice;
     }
 }

--- a/src/main/java/org/agoncal/sample/jhipster/bidirectmapstruct/service/mapper/InvoiceMapper.java
+++ b/src/main/java/org/agoncal/sample/jhipster/bidirectmapstruct/service/mapper/InvoiceMapper.java
@@ -1,27 +1,35 @@
 package org.agoncal.sample.jhipster.bidirectmapstruct.service.mapper;
 
-import org.agoncal.sample.jhipster.bidirectmapstruct.domain.*;
+import org.agoncal.sample.jhipster.bidirectmapstruct.domain.Invoice;
+import org.agoncal.sample.jhipster.bidirectmapstruct.domain.InvoiceLine;
 import org.agoncal.sample.jhipster.bidirectmapstruct.service.dto.InvoiceDTO;
-
-import org.mapstruct.*;
+import org.agoncal.sample.jhipster.bidirectmapstruct.service.dto.InvoiceLineDTO;
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 /**
  * Mapper for the entity Invoice and its DTO InvoiceDTO.
  */
-@Mapper(componentModel = "spring", uses = {ContactMapper.class})
-public interface InvoiceMapper extends EntityMapper<InvoiceDTO, Invoice> {
+@Mapper(componentModel = "spring", uses = ContactMapper.class)
+public interface InvoiceMapper {
 
-    
+    InvoiceDTO toDto(Invoice invoice);
 
-    @Mapping(target = "lines", ignore = true)
-    Invoice toEntity(InvoiceDTO invoiceDTO);
+    Invoice toEntity(InvoiceDTO invoiceDTO, @Context MappedInvoiceTrackingContext context);
 
-    default Invoice fromId(Long id) {
+    @Mapping(source = "invoice.id", target = "invoiceId")
+    @Mapping(source = "invoice.number", target = "invoiceNumber")
+    InvoiceLineDTO invoiceLineToInvoiceLineDto(InvoiceLine invoiceLine);
+
+    @Mapping(source = "invoiceId", target = "invoice")
+    InvoiceLine invoiceLineDtoInvoiceLine(InvoiceLineDTO invoiceLineDTO, @Context MappedInvoiceTrackingContext context);
+
+    default Invoice invoiceFromId(Long id, @Context MappedInvoiceTrackingContext context) {
         if (id == null) {
             return null;
         }
-        Invoice invoice = new Invoice();
-        invoice.setId(id);
-        return invoice;
+
+        return context.getMappedInvoiceById( id );
     }
 }

--- a/src/main/java/org/agoncal/sample/jhipster/bidirectmapstruct/service/mapper/MappedInvoiceTrackingContext.java
+++ b/src/main/java/org/agoncal/sample/jhipster/bidirectmapstruct/service/mapper/MappedInvoiceTrackingContext.java
@@ -1,0 +1,29 @@
+package org.agoncal.sample.jhipster.bidirectmapstruct.service.mapper;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import org.agoncal.sample.jhipster.bidirectmapstruct.domain.Invoice;
+import org.agoncal.sample.jhipster.bidirectmapstruct.service.dto.InvoiceDTO;
+import org.mapstruct.BeforeMapping;
+import org.mapstruct.Context;
+import org.mapstruct.MappingTarget;
+
+/**
+ * A type to be used as {@link Context} parameter to track mapped {@code Invoice} objects.
+ *
+ * @author Gunnar Morling
+ */
+public class MappedInvoiceTrackingContext {
+
+    private Map<Long, Invoice> invoicesById = new IdentityHashMap<>();
+
+    public Invoice getMappedInvoiceById(Long invoiceId) {
+        return invoicesById.get( invoiceId );
+    }
+
+    @BeforeMapping
+    public void storeMappedInstance(InvoiceDTO source, @MappingTarget Invoice target) {
+        invoicesById.put( source.getId(), target );
+    }
+}

--- a/src/test/java/org/agoncal/sample/jhipster/bidirectmapstruct/web/rest/InvoiceResourceIntTest.java
+++ b/src/test/java/org/agoncal/sample/jhipster/bidirectmapstruct/web/rest/InvoiceResourceIntTest.java
@@ -349,11 +349,4 @@ public class InvoiceResourceIntTest {
         invoiceDTO1.setId(null);
         assertThat(invoiceDTO1).isNotEqualTo(invoiceDTO2);
     }
-
-    @Test
-    @Transactional
-    public void testEntityFromId() {
-        assertThat(invoiceMapper.fromId(42L).getId()).isEqualTo(42);
-        assertThat(invoiceMapper.fromId(null)).isNull();
-    }
 }


### PR DESCRIPTION
when mapping an invoice DTO to an invoice, each referenced invoice line
will be mapped to a corresponding invoice line which references the parent
invoice entity; this is done using a mapping context parameter which is
passed to the mapping methods and keeps a reference to the root invoice

Hey @agoncal, I think I've got something working. For mapping entities to DTOs, I've added back the lines property to the invoice DTO. That way, when you get an invoice DTO, it will contain all its lines and contacts (there are no back references from invoice line DTO to invoice DTO, just the id and name).

The way back - from DTOs to entities - is a bit more tricky, the problem being that you'd like each invoice line entity to reference the same invoice entity instance. This is done by means of a mapping context parameter (new feature in MapStruct 1.2). A reference to the root invoice is stored at the beginning of the invoice mapping method. That way the root invoice can be obtained when mapping the invoice ids stored in the invoice line DTOs to the actual invoice object.

Hope it helps, if not let me know :) It's definitely very valuable feedback from a real-world application, so I'm very eager to make it work nicely, should it not be possible yet.